### PR TITLE
Adding color text styles for translations

### DIFF
--- a/style.css
+++ b/style.css
@@ -337,6 +337,38 @@ ul li.statistics_counter {
   display: none;
 }
 
+span.translations-red {
+  color: #ff3300;
+}
+
+span.translations-darkred {
+  color: #cc0033;
+}
+
+span.translations-brown {
+  color: #663300;  
+}
+
+span.translations-purple {
+  color: #9900ff;  
+}
+
+span.translations-grey {
+  color: #666633;  
+}
+
+span.translations-green {
+  color: #00cc00;  
+}
+
+span.translations-blue {
+  color: #0000cc;    
+}
+
+span.translations-violet {
+  color: #6633cc;    
+}
+
 /*
  * Translations TOC
  */


### PR DESCRIPTION
Добавление стилей отображения цветного текста в переводах, например, для перевода этого эссе: http://lesswrong.com/lw/k4/do_we_believe_everything_were_told/